### PR TITLE
Release 2.1.0: set default status for scans

### DIFF
--- a/lib/vigilion-rails.rb
+++ b/lib/vigilion-rails.rb
@@ -4,6 +4,7 @@ require "vigilion-rails/integrations/local_integration"
 require "vigilion-rails/configuration"
 
 module VigilionRails
+  PENDING_STATUS = 'pending'
 
   module ActiveRecord
     def scan_file column, options={}
@@ -25,6 +26,7 @@ module VigilionRails
             else
               #{integration_class}.new.scan key, self, :#{column}
             end
+            self.class.find(id).send('on_scan_#{column}', status: PENDING_STATUS)
           end
           @#{column}_old_url = #{column}.url
           return true

--- a/lib/vigilion-rails/version.rb
+++ b/lib/vigilion-rails/version.rb
@@ -1,3 +1,3 @@
 module VigilionRails
-  VERSION = "2.0.0"
+  VERSION = "2.1.0"
 end

--- a/spec/lib/integrations/local_integration_spec.rb
+++ b/spec/lib/integrations/local_integration_spec.rb
@@ -5,7 +5,7 @@ describe VigilionRails::LocalIntegration do
 
   describe "#scan" do
     it "calls vigilion scanner" do
-      document = CarrierwaveDocument.new
+      document = CarrierwaveDocument.create
       expect(Vigilion).to receive(:scan_path)
       document.scan_attachment!
     end


### PR DESCRIPTION
so that scheduled jobs have an initial status of pending as per Vigilion-Scanner's implementation

NB Includes a new gem release, see related PRs

https://app.asana.com/0/home/1178339044569632/1201853404384060