### PR TITLE
Skip scanning files after they have been deleted

### DIFF
--- a/lib/vigilion-rails.rb
+++ b/lib/vigilion-rails.rb
@@ -38,7 +38,7 @@ module VigilionRails
         end
 
         after_initialize :remember_#{column}_url
-        after_commit :check_scan_#{column}
+        after_commit :check_scan_#{column}, on: [:create, :update]
 
         def remember_#{column}_url
           @#{column}_old_url = #{column}.try(:url) unless new_record?

--- a/lib/vigilion-rails/version.rb
+++ b/lib/vigilion-rails/version.rb
@@ -1,3 +1,3 @@
 module VigilionRails
-  VERSION = "2.1.0"
+  VERSION = "2.2.0"
 end


### PR DESCRIPTION
The files probably don't need to be scanned after they have been deleted. Theoretically there should be no scan anyway as the URI are compared and if they don't change, the scan is skipped
```
        after_commit :check_scan_#{column}

        def check_scan_#{column}
          if @#{column}_old_url != #{column}.url
            scan_#{column}!
          end
        end
```
On AWS this is not true as AWS signature differ from request to request so the scan is always run resulting in error if run after attachment has been deleted. 